### PR TITLE
Modify Cargo.toml so that doug compiles easily on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ sorted-vec = "0.8.0"
 [dependencies.bevy]
 version = "0.7.0"
 default-features = false
+features = ["bevy_winit", "render"]
+
+[target.'cfg(unix)'.dependencies.bevy]
+version = "0.7.0"
+default-features = false
 features = ["bevy_winit", "render", "x11", "dynamic"]
 
 [profile.dev.package.layout21]


### PR DESCRIPTION
Disables the feature `dynamic` on Windows.